### PR TITLE
Only update last_execution on successful runs

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -145,7 +145,9 @@ function main() {
     sendDiscord(hoyoResp);
   }
 
-  scriptProperties.setProperty('last_execution', startExec);
+  if (!error) {
+    scriptProperties.setProperty('last_execution', startExec);
+  }
 }
 
 function discordPing() {


### PR DESCRIPTION
If the cookie expired, the script should pick up all the missing code since last successful run